### PR TITLE
Features/data 2605/add redis external option

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -47,7 +47,7 @@
   - name: AIRFLOW__CELERY__BROKER_URL
     valueFrom:
       secretKeyRef:
-        name: {{ .Release.Name }}-broker-url
+        name: {{ default (printf "%s-broker-url" .Release.Name) .Values.redis.brokerURLSecretName }}
         key: connection
   {{- end }}
   {{- if .Values.elasticsearch.enabled }}

--- a/chart/templates/redis/redis-networkpolicy.yaml
+++ b/chart/templates/redis/redis-networkpolicy.yaml
@@ -18,7 +18,8 @@
 ################################
 ## Airflow Redis NetworkPolicy
 #################################
-{{- if (and .Values.networkPolicies.enabled (eq .Values.executor "CeleryExecutor")) }}
+{{- $redis_is_deployed_by_chart := not (or .Values.redis.brokerURLSecretName .Values.redis.brokerURL) }}
+{{- if (and $redis_is_deployed_by_chart .Values.networkPolicies.enabled (eq .Values.executor "CeleryExecutor")) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/templates/redis/redis-service.yaml
+++ b/chart/templates/redis/redis-service.yaml
@@ -18,7 +18,8 @@
 ################################
 ## Airflow Redis Service
 #################################
-{{- if eq .Values.executor "CeleryExecutor" }}
+{{- $redis_is_deployed_by_chart := not (or .Values.redis.brokerURLSecretName .Values.redis.brokerURL) }}
+{{- if (and $redis_is_deployed_by_chart (eq .Values.executor "CeleryExecutor")) }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -18,7 +18,8 @@
 ################################
 ## Airflow Redis StatefulSet
 #################################
-{{- if eq .Values.executor "CeleryExecutor" }}
+{{- $redis_is_deployed_by_chart := not (or .Values.redis.brokerURLSecretName .Values.redis.brokerURL) }}
+{{- if (and $redis_is_deployed_by_chart (eq .Values.executor "CeleryExecutor")) }}
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/chart/templates/secrets/redis-secrets.yaml
+++ b/chart/templates/secrets/redis-secrets.yaml
@@ -14,13 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
 ################################
 ## Airflow Redis Password Secret
 #################################
+{{- $redis_is_deployed_by_chart := not (or .Values.redis.brokerURLSecretName .Values.redis.brokerURL) }}
+{{- $random_redis_password := randAlphaNum 10 }}
+{{- if eq .Values.executor "CeleryExecutor" }}
+{{- if (and $redis_is_deployed_by_chart (not .Values.redis.passwordSecretName)) }}
 # If both of these secret names are not set, we will either use the set password, or generate one
-{{- if not (and .Values.redis.passwordSecretName .Values.redis.brokerURLSecretName) }}
-{{ $random_redis_password := randAlphaNum 10 }}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -40,9 +41,11 @@ type: Opaque
 data:
   password: {{ (default $random_redis_password .Values.redis.password) | b64enc | quote }}
 ---
-################################
+{{- end }}
+{{- if not .Values.redis.brokerURLSecretName }}
+##################################
 ## Airflow Redis Connection Secret
-#################################
+##################################
 kind: Secret
 apiVersion: v1
 metadata:
@@ -57,5 +60,10 @@ metadata:
     "helm.sh/hook-weight": "0"
 type: Opaque
 data:
+{{- if $redis_is_deployed_by_chart }}
   connection: {{ (printf "redis://:%s@%s-redis:6379/0" (default $random_redis_password .Values.redis.password) .Release.Name) | b64enc | quote }}
+{{- else }}
+  connection: {{ (printf "%s" .Values.redis.brokerURL) | b64enc | quote }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -413,13 +413,18 @@ redis:
   #   cpu: 100m
   #   memory: 128Mi
 
-  # If set use as redis secret
-  passwordSecretName: ~
+  # if using an external redis, set one of those
+  ## Name of the secret with the full broker url
   brokerURLSecretName: ~
+  ## Full broker url
+  brokerURL: ~
 
-  # Else, if password is set, create secret with it,
-  # else generate a new one on install
+  # If using the internal redis of this chart
+  ## What is the name of the secret with the password
+  passwordSecretName: ~
+  ## Or what password should be used on instance creation
   password: ~
+  # Otherwise a new password will be generated on install
 
   # This setting tells kubernetes that its ok to evict
   # when it wants to scale a node down.


### PR DESCRIPTION
This adds options to bind an external redis in case of celery executor.
To test:
set

helm install airflow .
--set executor=CeleryExecutor 
--set redis.enabled=false
--set redis.url=123.456.789
Needs doc in readme
Thanks!
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

---
**^ Add meaningful description above**

Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/master/CONTRIBUTING.rst#pull-request-guidelines)** for more information.
In case of fundamental code change, Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvements+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in [UPDATING.md](https://github.com/apache/airflow/blob/master/UPDATING.md).
