### PR TITLE
simplier external redis version

### DIFF
--- a/chart/templates/_helpers.yaml
+++ b/chart/templates/_helpers.yaml
@@ -47,7 +47,7 @@
   - name: AIRFLOW__CELERY__BROKER_URL
     valueFrom:
       secretKeyRef:
-        name: {{ .Release.Name }}-broker-url
+        name: {{ default (printf "%s-broker-url" .Release.Name) .Values.redis.brokerURLSecretName }}
         key: connection
   {{- end }}
   {{- if .Values.elasticsearch.enabled }}

--- a/chart/templates/redis/redis-networkpolicy.yaml
+++ b/chart/templates/redis/redis-networkpolicy.yaml
@@ -18,7 +18,8 @@
 ################################
 ## Airflow Redis NetworkPolicy
 #################################
-{{- if and (eq .Values.redis.enabled true) (eq .Values.networkPolicies.enabled true) (eq .Values.executor "CeleryExecutor") }}
+{{- $redis_is_deployed_by_chart := not (or .Values.redis.brokerURLSecretName .Values.redis.brokerURL) }}
+{{- if (and $redis_is_deployed_by_chart .Values.networkPolicies.enabled (eq .Values.executor "CeleryExecutor")) }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/chart/templates/redis/redis-service.yaml
+++ b/chart/templates/redis/redis-service.yaml
@@ -18,7 +18,8 @@
 ################################
 ## Airflow Redis Service
 #################################
-{{- if and (eq .Values.executor "CeleryExecutor") (eq .Values.redis.enabled true) }}
+{{- $redis_is_deployed_by_chart := not (or .Values.redis.brokerURLSecretName .Values.redis.brokerURL) }}
+{{- if (and $redis_is_deployed_by_chart (eq .Values.executor "CeleryExecutor")) }}
 kind: Service
 apiVersion: v1
 metadata:

--- a/chart/templates/redis/redis-statefulset.yaml
+++ b/chart/templates/redis/redis-statefulset.yaml
@@ -18,7 +18,8 @@
 ################################
 ## Airflow Redis StatefulSet
 #################################
-{{- if and (eq .Values.executor "CeleryExecutor") (eq .Values.redis.enabled true) }}
+{{- $redis_is_deployed_by_chart := not (or .Values.redis.brokerURLSecretName .Values.redis.brokerURL) }}
+{{- if (and $redis_is_deployed_by_chart (eq .Values.executor "CeleryExecutor")) }}
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:

--- a/chart/templates/secrets/redis-secrets.yaml
+++ b/chart/templates/secrets/redis-secrets.yaml
@@ -14,15 +14,14 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-{{- if eq .Values.executor "CeleryExecutor" }}
 ################################
 ## Airflow Redis Password Secret
 #################################
-{{ $random_redis_password := randAlphaNum 10 }}
+{{- $redis_is_deployed_by_chart := not (or .Values.redis.brokerURLSecretName .Values.redis.brokerURL) }}
+{{- $random_redis_password := randAlphaNum 10 }}
+{{- if eq .Values.executor "CeleryExecutor" }}
+{{- if (and $redis_is_deployed_by_chart (not .Values.redis.passwordSecretName)) }}
 # If both of these secret names are not set, we will either use the set password, or generate one
-{{- if and (or (eq .Values.redis.enabled true) (.Values.redis.password)) (not (and .Values.redis.passwordSecretName .Values.redis.brokerURLSecretName)) }}
-# generating password only allowd in provisioned redis
 kind: Secret
 apiVersion: v1
 metadata:
@@ -43,10 +42,10 @@ data:
   password: {{ (default $random_redis_password .Values.redis.password) | b64enc | quote }}
 ---
 {{- end }}
-{{- if and (eq .Values.redis.enabled true) (not (and .Values.redis.passwordSecretName .Values.redis.brokerURLSecretName)) }}
-################################
+{{- if not .Values.redis.brokerURLSecretName }}
+##################################
 ## Airflow Redis Connection Secret
-#################################
+##################################
 kind: Secret
 apiVersion: v1
 metadata:
@@ -61,38 +60,10 @@ metadata:
     "helm.sh/hook-weight": "0"
 type: Opaque
 data:
+{{- if $redis_is_deployed_by_chart }}
   connection: {{ (printf "redis://:%s@%s-redis:6379/0" (default $random_redis_password .Values.redis.password) .Release.Name) | b64enc | quote }}
-{{- else if and .Values.redis.password .Values.redis.url  }}
-kind: Secret
-apiVersion: v1
-metadata:
-  name: {{ .Release.Name }}-broker-url
-  labels:
-    release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
-    heritage: {{ .Release.Service }}
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
-type: Opaque
-data:
-  connection: {{ (printf "redis://:%s@%s:6379/0" .Values.redis.password .Values.redis.url) | b64enc | quote }}
-{{- else if .Values.redis.url }}
-kind: Secret
-apiVersion: v1
-metadata:
-  name: {{ .Release.Name }}-broker-url
-  labels:
-    release: {{ .Release.Name }}
-    chart: {{ .Chart.Name }}
-    heritage: {{ .Release.Service }}
-  annotations:
-    "helm.sh/hook": "pre-install"
-    "helm.sh/hook-delete-policy": "before-hook-creation"
-    "helm.sh/hook-weight": "0"
-type: Opaque
-data:
-  connection: {{ (printf "redis://@%s:6379/0" .Values.redis.url) | b64enc | quote }}
+{{- else }}
+  connection: {{ (printf "%s" .Values.redis.brokerURL) | b64enc | quote }}
 {{- end }}
-{{- end}}
+{{- end }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -395,8 +395,6 @@ pgbouncer:
   logConnections: 0
 
 redis:
-  # set to true if redis resources/service should be created
-  enabled: false
   terminationGracePeriodSeconds: 600
 
   persistence:
@@ -415,15 +413,18 @@ redis:
   #   cpu: 100m
   #   memory: 128Mi
 
-  # If set use as redis secret
-  passwordSecretName: ~
+  # if using an external redis, set one of those
+  ## Name of the secret with the full broker url
   brokerURLSecretName: ~
-  # if using an external redis
-  url: ~
+  ## Full broker url
+  brokerURL: ~
 
-  # Else, if password is set, create secret with it,
-  # else generate a new one on install
+  # If using the internal redis of this chart
+  ## What is the name of the secret with the password
+  passwordSecretName: ~
+  ## Or what password should be used on instance creation
   password: ~
+  # Otherwise a new password will be generated on install
 
   # This setting tells kubernetes that its ok to evict
   # when it wants to scale a node down.


### PR DESCRIPTION
Tested.

Main changes:
* No new values that might be confusing,
* Make use of existing `brokerURLSecretName` (wasn't use in the chart otherwise, wierd)

```yaml
redis:
  brokerURL: "redis://fchehab-developers-1c-0:6379"
```

+ need to play with external permissions